### PR TITLE
Update dependencies to remove deprecation warnings

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -9,9 +9,10 @@ repository = { type = "github", user = "mooreryan", repo = "gleam_qcheck" }
 
 [dependencies]
 gleam_stdlib = "~> 0.47 or ~> 1.0"
-prng = "~> 3.0"
+prng = "~> 4.0"
 exception = ">= 2.0.0 and < 3.0.0"
 gleam_regexp = ">= 1.0.0 and < 2.0.0"
+gleam_yielder = ">= 1.1.0 and < 2.0.0"
 
 [dev-dependencies]
 birdie = ">= 1.1.2 and < 2.0.0"

--- a/gleam.toml
+++ b/gleam.toml
@@ -11,6 +11,7 @@ repository = { type = "github", user = "mooreryan", repo = "gleam_qcheck" }
 gleam_stdlib = "~> 0.47 or ~> 1.0"
 prng = "~> 3.0"
 exception = ">= 2.0.0 and < 3.0.0"
+gleam_regexp = ">= 1.0.0 and < 2.0.0"
 
 [dev-dependencies]
 birdie = ">= 1.1.2 and < 2.0.0"

--- a/gleam.toml
+++ b/gleam.toml
@@ -8,7 +8,7 @@ licences = ["Apache-2.0", "MIT"]
 repository = { type = "github", user = "mooreryan", repo = "gleam_qcheck" }
 
 [dependencies]
-gleam_stdlib = "~> 0.34 or ~> 1.0"
+gleam_stdlib = "~> 0.47 or ~> 1.0"
 prng = "~> 3.0"
 exception = ">= 2.0.0 and < 3.0.0"
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -15,10 +15,11 @@ packages = [
   { name = "gleam_json", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "thoas"], otp_app = "gleam_json", source = "hex", outer_checksum = "9063D14D25406326C0255BDA0021541E797D8A7A12573D849462CAFED459F6EB" },
   { name = "gleam_regexp", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "A3655FDD288571E90EE9C4009B719FEF59FA16AFCDF3952A76A125AF23CF1592" },
   { name = "gleam_stdlib", version = "0.47.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "3B22D46743C46498C8355365243327AC731ECD3959216344FA9CF9AD348620AC" },
+  { name = "gleam_yielder", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "8E4E4ECFA7982859F430C57F549200C7749823C106759F4A19A78AEA6687717A" },
   { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
   { name = "glexer", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "glexer", source = "hex", outer_checksum = "BD477AD657C2B637FEF75F2405FAEFFA533F277A74EF1A5E17B55B1178C228FB" },
   { name = "justin", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "justin", source = "hex", outer_checksum = "7FA0C6DB78640C6DC5FBFD59BF3456009F3F8B485BF6825E97E1EB44E9A1E2CD" },
-  { name = "prng", version = "3.0.3", build_tools = ["gleam"], requirements = ["gleam_bitwise", "gleam_stdlib"], otp_app = "prng", source = "hex", outer_checksum = "53006736FE23A0F61828C95B505193E10905D8DB76E128F1642D3E571E08F589" },
+  { name = "prng", version = "4.0.0", build_tools = ["gleam"], requirements = ["gleam_bitwise", "gleam_stdlib", "gleam_yielder"], otp_app = "prng", source = "hex", outer_checksum = "E452F957D19CCDC1B4BD12AA6E1B33194B1EB9C2BC0B3449D96E3585602EE3AE" },
   { name = "qcheck_gleeunit_utils", version = "0.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleeunit"], otp_app = "qcheck_gleeunit_utils", source = "hex", outer_checksum = "0C262D4636DEFC0BE8FA525DC193C2CC1E9D12A3BC26F9CA1F6B7FBB0E20C7B5" },
   { name = "rank", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "rank", source = "hex", outer_checksum = "5660E361F0E49CBB714CC57CC4C89C63415D8986F05B2DA0C719D5642FAD91C9" },
   { name = "simplifile", version = "2.1.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "BDD04F5D31D6D34E2EDFAEF0B68A6297AEC939888C3BFCE61133DE13857F6DA2" },
@@ -31,6 +32,7 @@ birdie = { version = ">= 1.1.2 and < 2.0.0" }
 exception = { version = ">= 2.0.0 and < 3.0.0" }
 gleam_regexp = { version = ">= 1.0.0 and < 2.0.0" }
 gleam_stdlib = { version = "~> 0.47 or ~> 1.0" }
+gleam_yielder = { version = ">= 1.1.0 and < 2.0.0" }
 gleeunit = { version = "~> 1.0" }
-prng = { version = "~> 3.0" }
+prng = { version = "~> 4.0" }
 qcheck_gleeunit_utils = { version = ">= 0.1.0 and < 0.2.0" }

--- a/manifest.toml
+++ b/manifest.toml
@@ -13,7 +13,7 @@ packages = [
   { name = "gleam_community_colour", version = "1.4.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "795964217EBEDB3DA656F5EB8F67D7AD22872EB95182042D3E7AFEF32D3FD2FE" },
   { name = "gleam_erlang", version = "0.26.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "3DF72F95F4716883FA51396FB0C550ED3D55195B541568CAF09745984FD37AD1" },
   { name = "gleam_json", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "thoas"], otp_app = "gleam_json", source = "hex", outer_checksum = "9063D14D25406326C0255BDA0021541E797D8A7A12573D849462CAFED459F6EB" },
-  { name = "gleam_stdlib", version = "0.40.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "86606B75A600BBD05E539EB59FABC6E307EEEA7B1E5865AFB6D980A93BCB2181" },
+  { name = "gleam_stdlib", version = "0.47.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "3B22D46743C46498C8355365243327AC731ECD3959216344FA9CF9AD348620AC" },
   { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
   { name = "glexer", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "glexer", source = "hex", outer_checksum = "BD477AD657C2B637FEF75F2405FAEFFA533F277A74EF1A5E17B55B1178C228FB" },
   { name = "justin", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "justin", source = "hex", outer_checksum = "7FA0C6DB78640C6DC5FBFD59BF3456009F3F8B485BF6825E97E1EB44E9A1E2CD" },
@@ -28,7 +28,7 @@ packages = [
 [requirements]
 birdie = { version = ">= 1.1.2 and < 2.0.0" }
 exception = { version = ">= 2.0.0 and < 3.0.0" }
-gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
+gleam_stdlib = { version = "~> 0.47 or ~> 1.0" }
 gleeunit = { version = "~> 1.0" }
 prng = { version = "~> 3.0" }
 qcheck_gleeunit_utils = { version = ">= 0.1.0 and < 0.2.0" }

--- a/manifest.toml
+++ b/manifest.toml
@@ -13,6 +13,7 @@ packages = [
   { name = "gleam_community_colour", version = "1.4.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "795964217EBEDB3DA656F5EB8F67D7AD22872EB95182042D3E7AFEF32D3FD2FE" },
   { name = "gleam_erlang", version = "0.26.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "3DF72F95F4716883FA51396FB0C550ED3D55195B541568CAF09745984FD37AD1" },
   { name = "gleam_json", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "thoas"], otp_app = "gleam_json", source = "hex", outer_checksum = "9063D14D25406326C0255BDA0021541E797D8A7A12573D849462CAFED459F6EB" },
+  { name = "gleam_regexp", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "A3655FDD288571E90EE9C4009B719FEF59FA16AFCDF3952A76A125AF23CF1592" },
   { name = "gleam_stdlib", version = "0.47.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "3B22D46743C46498C8355365243327AC731ECD3959216344FA9CF9AD348620AC" },
   { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
   { name = "glexer", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "glexer", source = "hex", outer_checksum = "BD477AD657C2B637FEF75F2405FAEFFA533F277A74EF1A5E17B55B1178C228FB" },
@@ -28,6 +29,7 @@ packages = [
 [requirements]
 birdie = { version = ">= 1.1.2 and < 2.0.0" }
 exception = { version = ">= 2.0.0 and < 3.0.0" }
+gleam_regexp = { version = ">= 1.0.0 and < 2.0.0" }
 gleam_stdlib = { version = "~> 0.47 or ~> 1.0" }
 gleeunit = { version = "~> 1.0" }
 prng = { version = "~> 3.0" }

--- a/src/qcheck.gleam
+++ b/src/qcheck.gleam
@@ -170,7 +170,7 @@ import gleam/int
 import gleam/iterator.{type Iterator}
 import gleam/list
 import gleam/option.{type Option, None, Some}
-import gleam/regex
+import gleam/regexp
 import gleam/result
 import gleam/set
 import gleam/string
@@ -1751,15 +1751,15 @@ fn new_test_error_message(
   )
 }
 
-fn regex_first_submatch(
+fn regexp_first_submatch(
   pattern pattern: String,
   in value: String,
 ) -> Result(String, String) {
-  regex.from_string(pattern)
-  // Convert regex.CompileError to a String
+  regexp.from_string(pattern)
+  // Convert regexp.CompileError to a String
   |> result.map_error(string.inspect)
   // Apply the regular expression
-  |> result.map(regex.scan(_, value))
+  |> result.map(regexp.scan(_, value))
   // We should see only a single match
   |> result.then(fn(matches) {
     case matches {
@@ -1769,7 +1769,7 @@ fn regex_first_submatch(
   })
   // We should see only a single successful submatch
   |> result.then(fn(match) {
-    let regex.Match(_content, submatches) = match
+    let regexp.Match(_content, submatches) = match
 
     case submatches {
       [Some(submatch)] -> Ok(submatch)
@@ -1782,21 +1782,21 @@ fn regex_first_submatch(
 fn test_error_message_get_original_value(
   test_error_str: String,
 ) -> Result(String, String) {
-  regex_first_submatch(pattern: "original_value: (.+?);", in: test_error_str)
+  regexp_first_submatch(pattern: "original_value: (.+?);", in: test_error_str)
 }
 
 /// Mainly for asserting values in qcheck internal tests.
 fn test_error_message_get_shrunk_value(
   test_error_str: String,
 ) -> Result(String, String) {
-  regex_first_submatch(pattern: "shrunk_value: (.+?);", in: test_error_str)
+  regexp_first_submatch(pattern: "shrunk_value: (.+?);", in: test_error_str)
 }
 
 /// Mainly for asserting values in qcheck internal tests.
 fn test_error_message_get_shrink_steps(
   test_error_str: String,
 ) -> Result(String, String) {
-  regex_first_submatch(pattern: "shrink_steps: (.+?);", in: test_error_str)
+  regexp_first_submatch(pattern: "shrink_steps: (.+?);", in: test_error_str)
 }
 
 /// This function should only be called to rescue a function that my call

--- a/src/qcheck.gleam
+++ b/src/qcheck.gleam
@@ -174,7 +174,7 @@ import gleam/regex
 import gleam/result
 import gleam/set
 import gleam/string
-import gleam/string_builder.{type StringBuilder}
+import gleam/string_tree.{type StringTree}
 import prng/random
 import prng/seed as prng_seed
 import qcheck/prng_random
@@ -1403,7 +1403,7 @@ pub fn char() {
 
 fn do_gen_string(
   i: Int,
-  string_builder: StringBuilder,
+  string_tree: StringTree,
   char_gen: Generator(String),
   char_trees_rev: List(Tree(String)),
   seed: Seed,
@@ -1414,13 +1414,13 @@ fn do_gen_string(
   // char_tree |> tree_to_string_(fn(x) { x }, 3) |> io.println
 
   case i <= 0 {
-    True -> #(string_builder.to_string(string_builder), char_trees_rev, seed)
+    True -> #(string_tree.to_string(string_tree), char_trees_rev, seed)
     False -> {
       let Tree(root, _) = char_tree
 
       do_gen_string(
         i - 1,
-        string_builder |> string_builder.append(root),
+        string_tree |> string_tree.append(root),
         char_gen,
         [char_tree, ..char_trees_rev],
         seed,
@@ -1441,7 +1441,7 @@ pub fn string_with_length_from(
 ) -> Generator(String) {
   Generator(fn(seed) {
     let #(generated_string, char_trees_rev, seed) =
-      do_gen_string(length, string_builder.new(), generator, [], seed)
+      do_gen_string(length, string_tree.new(), generator, [], seed)
 
     // TODO: Ideally this whole thing would be delayed until needed.
     let shrink = fn() {

--- a/test/examples/parsing_example_test.gleam
+++ b/test/examples/parsing_example_test.gleam
@@ -1,6 +1,6 @@
 import gleam/int
 import gleam/option.{Some}
-import gleam/regex.{Match}
+import gleam/regexp.{Match}
 import gleam/result
 import gleam/string
 import qcheck.{type Generator}
@@ -32,13 +32,13 @@ fn point_to_string(point: Point) -> String {
 fn point_of_string(string: String) -> Result(Point, String) {
   use re <- result.try(
     // This is the one that is intentionally broken:
-    // regex.from_string("\\((\\d+) (\\d+)\\)")
+    // regexp.from_string("\\((\\d+) (\\d+)\\)")
     // And this is the one that is fixed to be okay with negative integers.
-    regex.from_string("\\((-?\\d+) (-?\\d+)\\)")
+    regexp.from_string("\\((-?\\d+) (-?\\d+)\\)")
     |> result.map_error(string.inspect),
   )
 
-  use submatches <- result.try(case regex.scan(re, string) {
+  use submatches <- result.try(case regexp.scan(re, string) {
     [Match(_content, submatches)] -> Ok(submatches)
     _ -> Error("expected a single match")
   })

--- a/test/prng_random_test.gleam
+++ b/test/prng_random_test.gleam
@@ -4,11 +4,11 @@
 import gleam/dict.{type Dict}
 import gleam/float
 import gleam/int
-import gleam/iterator
 import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/order.{type Order}
 import gleam/string
+import gleam/yielder
 import gleeunit/should
 import prng/random
 import prng/seed
@@ -64,11 +64,11 @@ fn do_test(
 ) -> Nil {
   let number_of_samples = 1000
   let samples =
-    random.to_random_iterator(generator)
-    |> iterator.take(number_of_samples)
-    |> iterator.to_list
+    random.to_random_yielder(generator)
+    |> yielder.take(number_of_samples)
+    |> yielder.to_list
 
-  // The iterator should be infinite, so we _must_ always have 1000 samples
+  // The yielder should be infinite, so we _must_ always have 1000 samples
   list.length(samples)
   |> should.equal(number_of_samples)
 
@@ -84,13 +84,13 @@ fn behaves_the_same(gen1: random.Generator(a), gen2: random.Generator(a)) -> Nil
     |> random.random_sample
 
   let samples1 =
-    random.to_iterator(gen1, seed)
-    |> iterator.take(1000)
-    |> iterator.to_list
+    random.to_yielder(gen1, seed)
+    |> yielder.take(1000)
+    |> yielder.to_list
   let samples2 =
-    random.to_iterator(gen2, seed)
-    |> iterator.take(1000)
-    |> iterator.to_list
+    random.to_yielder(gen2, seed)
+    |> yielder.take(1000)
+    |> yielder.to_list
 
   should.equal(samples1, samples2)
 }
@@ -108,13 +108,13 @@ fn assert_similar_distributions(
     |> random.random_sample
 
   let samples1 =
-    random.to_iterator(gen1, seed)
-    |> iterator.take(100_000)
-    |> iterator.to_list
+    random.to_yielder(gen1, seed)
+    |> yielder.take(100_000)
+    |> yielder.to_list
   let samples2 =
-    random.to_iterator(gen2, seed)
-    |> iterator.take(100_000)
-    |> iterator.to_list
+    random.to_yielder(gen2, seed)
+    |> yielder.take(100_000)
+    |> yielder.to_list
 
   let proportions1 = samples1 |> frequencies |> proportions
   let proportions2 = samples2 |> frequencies |> proportions

--- a/test/qcheck/gen_algebra_test.gleam
+++ b/test/qcheck/gen_algebra_test.gleam
@@ -1,6 +1,6 @@
 import gleam/int
 import gleam/option.{Some}
-import gleam/regex
+import gleam/regexp
 import gleam/result
 import gleam/string
 import gleeunit/should
@@ -521,11 +521,11 @@ pub fn shrinking_works_with_apply__test() {
   }
 
   let parse_numbers = fn(str) {
-    regex.from_string("#\\((-?\\d+), (-?\\d+), (-?\\d+)\\)")
-    // Convert regex.CompileError to a String
+    regexp.from_string("#\\((-?\\d+), (-?\\d+), (-?\\d+)\\)")
+    // Convert regexp.CompileError to a String
     |> result.map_error(string.inspect)
     // Apply the regular expression
-    |> result.map(regex.scan(_, str))
+    |> result.map(regexp.scan(_, str))
     // We should see only a single match
     |> result.then(fn(matches) {
       case matches {
@@ -535,7 +535,7 @@ pub fn shrinking_works_with_apply__test() {
     })
     // Get submatches
     |> result.then(fn(match) {
-      let regex.Match(_content, submatches) = match
+      let regexp.Match(_content, submatches) = match
 
       case submatches {
         [Some(a), Some(b), Some(c)] -> Ok(#(a, b, c))

--- a/test/qcheck/gen_dict_test.gleam
+++ b/test/qcheck/gen_dict_test.gleam
@@ -28,17 +28,17 @@ pub fn dict_generic__generates_valid_values__test() {
   )
 }
 
-import gleam/string_builder
+import gleam/string_tree
 
 fn int_int_dict_to_string(d: dict.Dict(Int, Int)) -> String {
-  dict.fold(d, string_builder.from_string("{ "), fn(sb, k, v) {
-    string_builder.append(
+  dict.fold(d, string_tree.from_string("{ "), fn(sb, k, v) {
+    string_tree.append(
       sb,
       int.to_string(k) <> " => " <> int.to_string(v) <> ", ",
     )
   })
-  |> string_builder.append(" }")
-  |> string_builder.to_string()
+  |> string_tree.append(" }")
+  |> string_tree.to_string()
 }
 
 pub fn dict_generators_shrink_on_size_then_on_elements__test() {

--- a/test/qcheck/gen_string_test.gleam
+++ b/test/qcheck/gen_string_test.gleam
@@ -2,7 +2,7 @@ import birdie
 import gleam/function
 import gleam/iterator
 import gleam/list
-import gleam/regex
+import gleam/regexp
 import gleam/string
 import gleeunit/should
 import qcheck.{type Tree, Tree}
@@ -11,12 +11,12 @@ const test_count: Int = 5000
 
 pub fn string_generic__test() {
   let assert Ok(all_letters) =
-    regex.compile(
+    regexp.compile(
       "^[a-z]+$",
-      regex.Options(case_insensitive: False, multi_line: False),
+      regexp.Options(case_insensitive: False, multi_line: False),
     )
 
-  let has_only_a_through_z = fn(s) { regex.check(all_letters, s) }
+  let has_only_a_through_z = fn(s) { regexp.check(all_letters, s) }
 
   qcheck.run(
     config: qcheck.default_config(),
@@ -199,9 +199,9 @@ pub fn string_with_length__generates_length_n_strings__test() {
 
 pub fn string_from__generates_correct_values__test() {
   let assert Ok(all_ascii_lowercase) =
-    regex.compile(
+    regexp.compile(
       "^[a-z]+$",
-      regex.Options(case_insensitive: False, multi_line: False),
+      regexp.Options(case_insensitive: False, multi_line: False),
     )
 
   qcheck.run(
@@ -209,22 +209,22 @@ pub fn string_from__generates_correct_values__test() {
       |> qcheck.with_test_count(test_count),
     generator: qcheck.string_from(qcheck.char_lowercase()),
     property: fn(s) {
-      string.is_empty(s) || regex.check(all_ascii_lowercase, s)
+      string.is_empty(s) || regexp.check(all_ascii_lowercase, s)
     },
   )
 }
 
 pub fn string_non_empty_from__generates_correct_values__test() {
   let assert Ok(all_ascii_lowercase) =
-    regex.compile(
+    regexp.compile(
       "^[a-z]+$",
-      regex.Options(case_insensitive: False, multi_line: False),
+      regexp.Options(case_insensitive: False, multi_line: False),
     )
 
   qcheck.run(
     config: qcheck.default_config() |> qcheck.with_test_count(test_count),
     generator: qcheck.string_non_empty_from(qcheck.char_lowercase()),
-    property: fn(s) { regex.check(all_ascii_lowercase, s) },
+    property: fn(s) { regexp.check(all_ascii_lowercase, s) },
   )
 }
 

--- a/test/qcheck/gen_string_test.gleam
+++ b/test/qcheck/gen_string_test.gleam
@@ -1,9 +1,9 @@
 import birdie
 import gleam/function
-import gleam/iterator
 import gleam/list
 import gleam/regexp
 import gleam/string
+import gleam/yielder
 import gleeunit/should
 import qcheck.{type Tree, Tree}
 
@@ -133,12 +133,12 @@ fn check_tree_nodes(tree: Tree(a), predicate: fn(a) -> Bool) -> Bool {
 
   let all_true = fn(it) {
     it
-    |> iterator.all(function.identity)
+    |> yielder.all(function.identity)
   }
 
   case predicate(root) {
     True ->
-      iterator.map(children, fn(tree: Tree(a)) {
+      yielder.map(children, fn(tree: Tree(a)) {
         check_tree_nodes(tree, predicate)
       })
       |> all_true

--- a/test/qcheck/tree_test.gleam
+++ b/test/qcheck/tree_test.gleam
@@ -1,7 +1,7 @@
 import birdie
 import gleam/int
-import gleam/iterator
 import gleam/option.{None, Some}
+import gleam/yielder
 import gleeunit/should
 import qcheck.{type Tree, Tree}
 
@@ -101,7 +101,7 @@ fn my_int_towards_zero() {
   fn(my_int) {
     let MyInt(n) = my_int
     qcheck.shrink_int_towards_zero()(n)
-    |> iterator.map(MyInt)
+    |> yielder.map(MyInt)
   }
 }
 


### PR DESCRIPTION
Move to new packages or new modules to remove deprecation warnings:

- **Move from gleam/iterator to gleam/yielder**
- **Move from gleam/regex to gleam/regexp**
- **Move from gleam/string_builder to gleam/string_tree**
