### PR TITLE
Update function names in README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Okay, first we need to write a generator of valid points. In this case, it isn't
 
 ```gleam
 fn point_generator() {
-  qcheck.map2(qcheck.int_uniform(), qcheck.int_uniform(), make_point)
+  qcheck.map2(qcheck.uniform_int(), qcheck.uniform_int(), make_point)
 }
 ```
 
@@ -153,7 +153,7 @@ Alternatively, if you prefer the `use` syntax, you could write:
 
 ```gleam
 fn point_generator() {
-  use x, y <- qcheck.map2(qcheck.int_uniform(), qcheck.int_uniform())
+  use x, y <- qcheck.map2(qcheck.uniform_int(), qcheck.uniform_int())
 
   make_point(x, y)
 }
@@ -232,13 +232,13 @@ fn box_generator() {
     Box(x:, y:, w:, h:)
   })
   // Set the `x` generator.
-  |> qcheck.apply(qcheck.int_uniform_inclusive(-100, 100))
+  |> qcheck.apply(qcheck.bounded_int(-100, 100))
   // Set the `y` generator.
-  |> qcheck.apply(qcheck.int_uniform_inclusive(-100, 100))
+  |> qcheck.apply(qcheck.bounded_int(-100, 100))
   // Set the `width` generator.
-  |> qcheck.apply(qcheck.int_uniform_inclusive(1, 100))
+  |> qcheck.apply(qcheck.bounded_int(1, 100))
   // Set the `height` generator.
-  |> qcheck.apply(qcheck.int_uniform_inclusive(1, 100))
+  |> qcheck.apply(qcheck.bounded_int(1, 100))
 }
 ```
 


### PR DESCRIPTION
1a8c6729554bc9e5222131ff701ed39ff0ef6b8b changed a lot of function names, and when copying an example from the README for modifying it, I found that it wouldn't compile. So I just ran a quick ripgrep[^1] and updated most of the cases of old function names (only found in the README) to new ones.

[^1]: `rg 'int_uniform|int_uniform_inclusive|int_small_positive_or_zero|int_small_strictly_positive|char_uniform_inclusive|char_utf_codepoint|char_uppercase|char_lowercase|char_digit|char_printable_uniform|char_uniform|char_alpha|char_alpha_numeric|char_from_list|char_whitespace|char_printable|string_non_empty|string_with_length|string_with_length_from|string_non_empty_from|string_generic|bit_array_non_empty|bit_array_with_size_from|bit_array_with_size|bit_array_utf8|bit_array_utf8_non_empty|bit_array_utf8_with_size|bit_array_utf8_with_size_from|bit_array_byte_aligned|bit_array_byte_aligned_non_empty|bit_array_byte_aligned_with_size|bit_array_byte_aligned_with_size_from|(list|dict|set)_generic|seed_random|small_positive_or_zero_int|float_uniform_inclusive'` in case you're curious.